### PR TITLE
Update data refresh logic

### DIFF
--- a/src/app/api/month/route.ts
+++ b/src/app/api/month/route.ts
@@ -78,10 +78,13 @@ export async function GET() {
     // Calculate potential savings by the end of the month
     const potentialSavings = flowRateSecond * remainingSecondsInMonth
 
-    // Return all burn rates and earn rates in the API response
-    return NextResponse.json({ 
-      burnRateSecond, 
-      burnRateMinute, 
+    // Return raw values and all calculated rates in the API response
+    return NextResponse.json({
+      rawExpenses: expensesSum,
+      rawIncome: incomeSum,
+      rawEstimatedIncome: estimatedIncomeSum,
+      burnRateSecond,
+      burnRateMinute,
       burnRateHour,
       earnRateSecond,
       earnRateMinute,


### PR DESCRIPTION
## Summary
- add raw data to `/api/month` response
- poll server every 15 seconds and compute burn/flow rates in the browser

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a464d590c83239a265cd51e3c43d3