### PR TITLE
Show full timeline with current hour

### DIFF
--- a/src/components/HourlySavingsTimeline.tsx
+++ b/src/components/HourlySavingsTimeline.tsx
@@ -3,7 +3,11 @@
 import { useEffect, useState } from 'react'
 
 interface HourEntry { hour: number; avg: number }
-interface Stats { hourly: HourEntry[]; totalToday: number; totalYesterday: number }
+interface Stats {
+  hourly: HourEntry[]
+  totalToday: number
+  totalYesterday: number
+}
 
 export default function HourlySavingsTimeline() {
   const [stats, setStats] = useState<Stats>({ hourly: [], totalToday: 0, totalYesterday: 0 })
@@ -20,22 +24,46 @@ export default function HourlySavingsTimeline() {
     return () => clearInterval(interval)
   }, [])
 
+  const hourMap = new Map<number, number>(stats.hourly.map((h) => [h.hour, h.avg]))
+  const hours = Array.from({ length: 24 }, (_, i) => i)
+  const currentHour = new Date().getHours()
+
   return (
     <div className="mx-8 my-6">
       <h2 className="text-xl font-semibold mb-2">🕑 Savings by Hour</h2>
       <div className="flex items-end space-x-2 overflow-x-auto">
-        {stats.hourly.map((h) => (
-          <div key={h.hour} className="text-center">
-            <div className={`px-2 py-1 rounded ${h.avg >= 0 ? 'bg-green-100 text-green-600' : 'bg-red-100 text-red-600'}`}>
-              {h.avg.toFixed(2)}
+        {hours.map((hour) => {
+          const avg = hourMap.get(hour)
+          const isNow = hour === currentHour
+          return (
+            <div
+              key={hour}
+              className={`text-center ${isNow ? 'border-b-2 border-blue-500' : ''}`}
+            >
+              <div
+                className={`px-2 py-1 rounded ${
+                  avg === undefined
+                    ? 'bg-gray-100 text-gray-400'
+                    : avg >= 0
+                    ? 'bg-green-100 text-green-600'
+                    : 'bg-red-100 text-red-600'
+                }`}
+              >
+                {avg === undefined ? '-' : avg.toFixed(2)}
+              </div>
+              <div className="text-sm text-gray-500">{hour}:00</div>
             </div>
-            <div className="text-sm text-gray-500">{h.hour}:00</div>
-          </div>
-        ))}
+          )
+        })}
       </div>
       <div className="mt-2 text-lg">
-        Total today: <span className={stats.totalToday >= 0 ? 'text-green-600' : 'text-red-600'}>{stats.totalToday.toFixed(2)} PLN</span>
-        <span className="text-sm text-gray-500 ml-2">(yesterday {stats.totalYesterday.toFixed(2)} PLN)</span>
+        Total today:{' '}
+        <span className={stats.totalToday >= 0 ? 'text-green-600' : 'text-red-600'}>
+          {stats.totalToday.toFixed(2)} PLN
+        </span>
+        <span className="text-sm text-gray-500 ml-2">
+          (yesterday {stats.totalYesterday.toFixed(2)} PLN)
+        </span>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- extend hourly savings chart to show all 24 hours
- highlight the current hour and display `-` when no data is available

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_686ce142a7b48323b47c8a20eb68b536