### PR TITLE
Implement backend cron script for burn rates

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "cron": "node scripts/recordFlowRate.js"
   },
   "dependencies": {
     "axios": "^1.10.0",

--- a/scripts/recordFlowRate.js
+++ b/scripts/recordFlowRate.js
@@ -1,0 +1,62 @@
+const axios = require('axios')
+const Database = require('better-sqlite3')
+const path = require('path')
+require('dotenv/config')
+
+const dbPath = path.join(process.cwd(), 'burnrate.db')
+const db = new Database(dbPath)
+db.exec(`CREATE TABLE IF NOT EXISTS burn_rates (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  timestamp INTEGER NOT NULL,
+  value REAL NOT NULL
+)`)
+
+async function fetchMonth() {
+  const token = process.env.AIRTABLE_TOKEN
+  const baseId = process.env.AIRTABLE_BASE_ID
+  if (!token || !baseId) {
+    throw new Error('Missing AIRTABLE_TOKEN or AIRTABLE_BASE_ID')
+  }
+  const url = `https://api.airtable.com/v0/${baseId}/months`
+  const res = await axios.get(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  return res.data.records
+}
+
+function computeFlowRateMinute(records) {
+  const lipiec = records.find(r => r.fields.Name === 'Lipiec')
+  if (!lipiec) throw new Error('Month Lipiec not found')
+
+  const rawExpenses = String(lipiec.fields['expenses_sum'] || '0')
+  const expensesSum = parseFloat(rawExpenses.replace('PLN', '').replace(',', '').trim())
+
+  const rawEstimatedIncome = String(lipiec.fields['estimated_income_sum'] || '0')
+  const estimatedIncomeSum = parseFloat(rawEstimatedIncome.replace('PLN', '').replace('-', '').replace(',', '').trim())
+
+  const startOfMonth = new Date('2025-07-01T00:00:00')
+  const now = new Date()
+  const secondsPassed = Math.floor((now.getTime() - startOfMonth.getTime()) / 1000)
+
+  const endOfMonth = new Date('2025-07-31T23:59:59')
+  const totalMinutesInMonth = Math.floor((endOfMonth.getTime() - startOfMonth.getTime()) / 1000 / 60)
+
+  const burnRateMinute = secondsPassed > 0 ? expensesSum / (secondsPassed / 60) : 0
+  const earnRateMinute = totalMinutesInMonth > 0 ? estimatedIncomeSum / totalMinutesInMonth : 0
+  return earnRateMinute - burnRateMinute
+}
+
+async function main() {
+  try {
+    const records = await fetchMonth()
+    const value = computeFlowRateMinute(records)
+    const stmt = db.prepare('INSERT INTO burn_rates (timestamp, value) VALUES (?, ?)')
+    stmt.run(Date.now(), value)
+    console.log('Recorded value', value)
+  } catch (err) {
+    console.error(err)
+    process.exit(1)
+  }
+}
+
+main()

--- a/src/components/HourlySavingsTimeline.tsx
+++ b/src/components/HourlySavingsTimeline.tsx
@@ -31,14 +31,14 @@ export default function HourlySavingsTimeline() {
   return (
     <div className="mx-8 my-6">
       <h2 className="text-xl font-semibold mb-2">🕑 Savings by Hour</h2>
-      <div className="flex items-end space-x-2 overflow-x-auto">
+      <div className="flex items-end overflow-x-auto w-full gap-2">
         {hours.map((hour) => {
           const avg = hourMap.get(hour)
           const isNow = hour === currentHour
           return (
             <div
               key={hour}
-              className={`text-center ${isNow ? 'border-b-2 border-blue-500' : ''}`}
+              className={`flex-1 text-center ${isNow ? 'border-b-2 border-blue-500' : ''}`}
             >
               <div
                 className={`px-2 py-1 rounded ${


### PR DESCRIPTION
## Summary
- create a `recordFlowRate.js` script to periodically store flow rates
- hook cron script via `npm run cron`
- spread hourly timeline bars across screen for full width

## Testing
- `npm run build`
- `npm run cron` *(fails: Error [ERR_BAD_REQUEST]: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686e188b9c3483239a47bbe7e264467d