### PR TITLE
Add daily spending challenge widget

### DIFF
--- a/src/app/api/challenge/route.ts
+++ b/src/app/api/challenge/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server'
+import axios from 'axios'
+import { fetchBurnRates } from '@/lib/supabase'
+
+export async function GET() {
+  const token = process.env.AIRTABLE_TOKEN
+  const baseId = process.env.AIRTABLE_BASE_ID
+  if (!token || !baseId) {
+    return NextResponse.json({ error: 'Missing Airtable credentials' }, { status: 500 })
+  }
+
+  const url = `https://api.airtable.com/v0/${baseId}/months`
+  try {
+    const response = await axios.get(url, { headers: { Authorization: `Bearer ${token}` } })
+    const records = response.data.records
+    const lipiec = records.find((r: any) => r.fields.Name === 'Lipiec')
+    if (!lipiec) {
+      return NextResponse.json({ error: 'Month Lipiec not found' }, { status: 404 })
+    }
+    const rawExpenses = parseFloat(String(lipiec.fields['expenses_sum'] || '0').replace(/[^0-9.-]/g, ''))
+    if (Number.isNaN(rawExpenses)) throw new Error('Invalid expenses sum')
+
+    const now = new Date()
+    const startToday = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+    const startYesterday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1)
+
+    const rowsToday = await fetchBurnRates(startToday.getTime(), now.getTime())
+    const rowsYesterday = await fetchBurnRates(startYesterday.getTime(), startToday.getTime())
+    const totalToday = rowsToday.reduce((s, r) => s + r.value, 0)
+    const totalYesterday = rowsYesterday.reduce((s, r) => s + r.value, 0)
+
+    const spentToday = totalToday < 0 ? -totalToday : 0
+    const spentYesterday = totalYesterday < 0 ? -totalYesterday : 0
+
+    const dayOfMonth = now.getDate()
+    const avgDaily = rawExpenses / dayOfMonth
+    const challengeLimit = avgDaily * 0.99
+
+    return NextResponse.json({
+      challengeLimit,
+      spentToday,
+      spentYesterday
+    })
+  } catch (err: any) {
+    console.error(err)
+    return NextResponse.json({ error: err.message }, { status: 500 })
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useRef } from 'react'
 import HourlySavingsTimeline from '../components/HourlySavingsTimeline'
+import DailyChallenge from '../components/DailyChallenge'
 
 export default function HomePage() {
   const [data, setData] = useState({
@@ -138,6 +139,8 @@ export default function HomePage() {
       </div>
 
       <HourlySavingsTimeline />
+
+      <DailyChallenge />
       
       {/* Toggle Button */}
       <button 

--- a/src/components/DailyChallenge.tsx
+++ b/src/components/DailyChallenge.tsx
@@ -1,0 +1,47 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+interface ChallengeData {
+  challengeLimit: number
+  spentToday: number
+  spentYesterday: number
+}
+
+export default function DailyChallenge() {
+  const [data, setData] = useState<ChallengeData | null>(null)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/challenge')
+        if (!res.ok) throw new Error('Request failed')
+        const json = await res.json()
+        setData(json)
+      } catch (err) {
+        console.error(err)
+      }
+    }
+    fetchData()
+    const interval = setInterval(fetchData, 60000)
+    return () => clearInterval(interval)
+  }, [])
+
+  if (!data) return <div>Loading challenge...</div>
+
+  const progress = Math.min((data.spentToday / data.challengeLimit) * 100, 100)
+
+  return (
+    <div className="mt-8 mx-8 p-4 rounded-xl border border-blue-200 bg-blue-50 text-gray-800">
+      <div className="font-semibold mb-2">
+        Wyzwanie: wydaj dziś nie więcej niż {data.challengeLimit.toFixed(2)} PLN
+      </div>
+      <div className="mb-2 text-sm">Wydane dziś: {data.spentToday.toFixed(2)} PLN</div>
+      <div className="w-full bg-gray-200 h-4 rounded">
+        <div
+          className="h-4 bg-green-500 rounded"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- introduce `/api/challenge` to compute a daily spending challenge
- add `DailyChallenge` component fetching that API
- render the challenge on the home page

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_687379718c108323873166b51d6cc41b