### PR TITLE
Exclude fixed expenses from daily challenge

### DIFF
--- a/src/app/api/challenge/route.ts
+++ b/src/app/api/challenge/route.ts
@@ -62,7 +62,13 @@ export async function GET() {
     endToday.setDate(endToday.getDate() + 1)
 
     for (const rec of records) {
-      const val = parseFloat(String(rec.fields.Value || '0').replace(/[^0-9.-]/g, ''))
+      const fixed = rec.fields['fixed_expense']
+      const isFixed = fixed === true || String(fixed).toLowerCase() === 'true'
+      if (isFixed) continue
+
+      const val = parseFloat(
+        String(rec.fields.Value || '0').replace(/[^0-9.-]/g, '')
+      )
       if (Number.isNaN(val) || val <= 0) continue
       const raw = String(rec.fields['transaction date'] || '')
       const parsed = parseTransactionDate(raw)


### PR DESCRIPTION
## Summary
- skip Airtable records marked as `fixed_expense` when computing daily challenge

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687506f59aa08323a3f5c3cd47219fd0