### PR TITLE
Add flow rate candlestick chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@supabase/supabase-js": "^2.50.4",
         "axios": "^1.10.0",
         "dotenv": "^17.0.1",
+        "lightweight-charts": "^5.0.8",
         "next": "15.3.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -1298,6 +1299,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/fancy-canvas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fancy-canvas/-/fancy-canvas-2.1.0.tgz",
+      "integrity": "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==",
+      "license": "MIT"
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
@@ -1707,6 +1714,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightweight-charts": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-5.0.8.tgz",
+      "integrity": "sha512-dNBK5TlNcG78RUnxYRAZP4XpY5bkp3EE0PPjFFPkdIZ8RvnvL2JLgTb1BLh40trHhgJl51b1bCz8678GpnKvIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fancy-canvas": "2.1.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@supabase/supabase-js": "^2.50.4",
     "axios": "^1.10.0",
     "dotenv": "^17.0.1",
+    "lightweight-charts": "^5.0.8",
     "next": "15.3.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/src/app/api/burnrate/history/route.ts
+++ b/src/app/api/burnrate/history/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server'
+import { fetchBurnRates } from '@/lib/supabase'
+
+/**
+ * Returns hourly candlestick data for all recorded flow rates.
+ * Each entry contains the hour timestamp (start of hour) and
+ * open, high, low, close values aggregated from minute samples.
+ */
+export async function GET() {
+  // fetch all records from the beginning of time
+  const now = Date.now()
+  let rows: { timestamp: number; value: number }[] = []
+  try {
+    rows = await fetchBurnRates(0, now)
+  } catch (err) {
+    console.error(err)
+  }
+
+  rows.sort((a, b) => a.timestamp - b.timestamp)
+
+  const map = new Map<number, { open: number; high: number; low: number; close: number }>()
+  for (const r of rows) {
+    const date = new Date(r.timestamp)
+    const hourTs = new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours()).getTime()
+    const entry = map.get(hourTs)
+    if (!entry) {
+      map.set(hourTs, { open: r.value, high: r.value, low: r.value, close: r.value })
+    } else {
+      entry.high = Math.max(entry.high, r.value)
+      entry.low = Math.min(entry.low, r.value)
+      entry.close = r.value
+    }
+  }
+
+  const candles = Array.from(map.entries())
+    .sort((a, b) => a[0] - b[0])
+    .map(([ts, ohlc]) => ({ timestamp: ts, ...ohlc }))
+
+  return NextResponse.json({ candles })
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useRef } from 'react'
 import HourlySavingsTimeline from '../components/HourlySavingsTimeline'
+import FlowRateCandlestick from '../components/FlowRateCandlestick'
 import DailyChallenge from '../components/DailyChallenge'
 
 export default function HomePage() {
@@ -139,6 +140,8 @@ export default function HomePage() {
       </div>
 
       <HourlySavingsTimeline />
+
+      <FlowRateCandlestick />
 
       <DailyChallenge />
       

--- a/src/components/FlowRateCandlestick.tsx
+++ b/src/components/FlowRateCandlestick.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
-import { createChart, CandlestickSeriesOptions } from 'lightweight-charts'
+import { createChart, CandlestickSeries, CandlestickSeriesPartialOptions, UTCTimestamp } from 'lightweight-charts'
 
 interface Candle {
   timestamp: number
@@ -22,7 +22,7 @@ export default function FlowRateCandlestick() {
       width: containerRef.current.clientWidth,
       height: 300,
     })
-    const series = chartRef.current.addCandlestickSeries({} as CandlestickSeriesOptions)
+    const series = chartRef.current.addSeries(CandlestickSeries, {} as CandlestickSeriesPartialOptions)
 
     const fetchData = async () => {
       try {
@@ -30,7 +30,7 @@ export default function FlowRateCandlestick() {
         if (!res.ok) throw new Error('Request failed')
         const json = await res.json()
         const data = (json.candles as Candle[]).map(c => ({
-          time: c.timestamp / 1000,
+          time: (c.timestamp / 1000) as UTCTimestamp,
           open: c.open,
           high: c.high,
           low: c.low,

--- a/src/components/FlowRateCandlestick.tsx
+++ b/src/components/FlowRateCandlestick.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { createChart, CandlestickSeriesOptions } from 'lightweight-charts'
+
+interface Candle {
+  timestamp: number
+  open: number
+  high: number
+  low: number
+  close: number
+}
+
+export default function FlowRateCandlestick() {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const chartRef = useRef<ReturnType<typeof createChart> | null>(null)
+
+  useEffect(() => {
+    if (!containerRef.current) return
+
+    chartRef.current = createChart(containerRef.current, {
+      width: containerRef.current.clientWidth,
+      height: 300,
+    })
+    const series = chartRef.current.addCandlestickSeries({} as CandlestickSeriesOptions)
+
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/burnrate/history')
+        if (!res.ok) throw new Error('Request failed')
+        const json = await res.json()
+        const data = (json.candles as Candle[]).map(c => ({
+          time: c.timestamp / 1000,
+          open: c.open,
+          high: c.high,
+          low: c.low,
+          close: c.close,
+        }))
+        series.setData(data)
+      } catch (err) {
+        console.error(err)
+      }
+    }
+
+    fetchData()
+
+    const handleResize = () => {
+      if (containerRef.current && chartRef.current) {
+        chartRef.current.applyOptions({ width: containerRef.current.clientWidth })
+      }
+    }
+
+    window.addEventListener('resize', handleResize)
+    return () => {
+      window.removeEventListener('resize', handleResize)
+      chartRef.current?.remove()
+    }
+  }, [])
+
+  return <div ref={containerRef} />
+}


### PR DESCRIPTION
## Summary
- add lightweight-charts dependency
- expose hourly candlestick data via `/api/burnrate/history`
- create `FlowRateCandlestick` component for chart rendering
- show the candlestick chart on the main page

## Testing
- `npm run lint` *(fails: prompts for initial ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6876363843048323bb0243b6bd8b991a