### PR TITLE
Add Spend-RPM gauge

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,8 @@ If you open the application with the React Developer Tools browser extension act
 ### Data refresh frequency
 The widget fetches data from `/api/month` every 15 seconds. Computed burn and earn rates are updated once per second to provide a smooth display. Network requests should therefore occur every 15 seconds.
 
+### Spend‑RPM gauge
+Visit `/rpm` to see a simple gauge visualising the current cash burn speed. The indicator compares the actual burn rate with the planned allowance and updates once per second.
+
 ### Automated cron job
 Burn rate samples are stored server-side by a Vercel cron job. The job calls `/api/cron` every minute with the `CRON_SECRET` value in the `Authorization` header. Set the same secret in your project environment so the endpoint can authenticate the request.

--- a/src/app/rpm/page.tsx
+++ b/src/app/rpm/page.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import SpendRpmGauge from '@/components/SpendRpmGauge'
+
+interface MonthData {
+  rawExpenses: number
+  rawEstimatedIncome: number
+}
+
+export default function SpendRpmPage() {
+  const [month, setMonth] = useState<MonthData | null>(null)
+  const [rpm, setRpm] = useState(0)
+  const [percent, setPercent] = useState(0)
+
+  // Fetch month data periodically
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/month')
+        if (!res.ok) throw new Error('Request failed')
+        const json = await res.json()
+        setMonth({
+          rawExpenses: json.rawExpenses,
+          rawEstimatedIncome: json.rawEstimatedIncome
+        })
+      } catch (err) {
+        console.error(err)
+      }
+    }
+    fetchData()
+    const interval = setInterval(fetchData, 15000)
+    return () => clearInterval(interval)
+  }, [])
+
+  // Compute RPM every second
+  useEffect(() => {
+    if (!month) return
+    const startOfMonth = new Date('2025-07-01T00:00:00')
+    const daysInMonth = 31
+    const allowanceSec =
+      ((month.rawEstimatedIncome ?? 0) / daysInMonth) / 86400
+
+    const update = () => {
+      const t = Math.max(
+        (Date.now() - startOfMonth.getTime()) / 1000,
+        1
+      )
+      const burnSec = (month.rawExpenses ?? 0) / t
+      const r = burnSec / allowanceSec
+      setRpm(r)
+      setPercent(Math.min(r / 2, 1))
+    }
+
+    update()
+    const interval = setInterval(update, 1000)
+    return () => clearInterval(interval)
+  }, [month])
+
+  return (
+    <div className="flex items-center justify-center h-screen">
+      {month ? <SpendRpmGauge percent={percent} rpm={rpm} /> : 'Loading...'}
+    </div>
+  )
+}

--- a/src/components/SpendRpmGauge.tsx
+++ b/src/components/SpendRpmGauge.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+interface Props {
+  percent: number // 0..1
+  rpm: number
+}
+
+export default function SpendRpmGauge({ percent, rpm }: Props) {
+  const angle = -90 + percent * 180
+  const color = rpm > 1.3 ? '#dc2626' : rpm > 1 ? '#fbbf24' : '#16a34a'
+
+  return (
+    <div className="relative w-64 h-32">
+      <svg viewBox="0 0 100 50" className="w-full h-full">
+        <path d="M10 50 A40 40 0 0 1 90 50" fill="none" stroke="#e5e7eb" strokeWidth="10" />
+      </svg>
+      <div
+        className="absolute bottom-0 left-1/2"
+        style={{
+          transform: `translateX(-50%) rotate(${angle}deg)`,
+          transformOrigin: 'bottom center'
+        }}
+      >
+        <div style={{ width: 2, height: 45, backgroundColor: color }} />
+      </div>
+      <div className="absolute inset-x-0 bottom-0 text-center font-mono text-xl mt-2">
+        {rpm.toFixed(2)}x
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `SpendRpmGauge` component with a simple tachometer-like indicator
- create `/rpm` route displaying the new gauge
- document the Spend‑RPM screen in the README

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68769e53b85883239634c78f4f4ff40d